### PR TITLE
Refactor: Move metadata generation to layout for QnA pages

### DIFF
--- a/app/(dashboard)/qna/layout.tsx
+++ b/app/(dashboard)/qna/layout.tsx
@@ -1,9 +1,17 @@
+import { Metadata } from 'next'
 import React, { ReactNode } from 'react'
 
 import Breadcrumbs from '@/components/breadcrumbs/Breadcrumb'
 import { qnaPath } from '@/config/paths'
 import { reportListPath } from '@/config/paths/list-of-report-path'
 import PageHeaderHandler from '@/handlers/page-header-handler/PageHeaderHandler'
+import { ENV } from '@/libs/env'
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: `QNA - ${ENV.NEXT_PUBLIC_PROJECT_NAME}`
+  }
+}
 
 const breadcrumbs = [
   { key: 'pepito-market', label: 'Pepito Market', href: '/' },

--- a/app/(dashboard)/qna/select-equipment/ac/asset-list/page.tsx
+++ b/app/(dashboard)/qna/select-equipment/ac/asset-list/page.tsx
@@ -1,17 +1,9 @@
-import { Metadata } from 'next'
 import { getTranslations } from 'next-intl/server'
 import React from 'react'
 
 import Description from '@/components/description/Description'
-import { ENV } from '@/libs/env'
 
 import AssetListForm from './_components/asset-list-form/AssetListForm'
-
-export async function generateMetadata(): Promise<Metadata> {
-  return {
-    title: `Asset List - ${ENV.NEXT_PUBLIC_PROJECT_NAME}`
-  }
-}
 
 const Page = async () => {
   const t = await getTranslations('qna')

--- a/app/(dashboard)/qna/select-equipment/ac/asset-list/review/page.tsx
+++ b/app/(dashboard)/qna/select-equipment/ac/asset-list/review/page.tsx
@@ -1,17 +1,9 @@
-import { Metadata } from 'next'
 import { getTranslations } from 'next-intl/server'
 import React from 'react'
 
 import Description from '@/components/description/Description'
-import { ENV } from '@/libs/env'
 
 import AssetListForm from '../_components/asset-list-form/AssetListForm'
-
-export async function generateMetadata(): Promise<Metadata> {
-  return {
-    title: `Asset List Review - ${ENV.NEXT_PUBLIC_PROJECT_NAME}`
-  }
-}
 
 const Page = async () => {
   const t = await getTranslations('qna')

--- a/app/(dashboard)/qna/select-equipment/ac/details-forms/review/page.tsx
+++ b/app/(dashboard)/qna/select-equipment/ac/details-forms/review/page.tsx
@@ -1,15 +1,6 @@
-import { Metadata } from 'next'
 import React, { Suspense } from 'react'
 
-import { ENV } from '@/libs/env'
-
 import ReviewTabs from './_components/review-tabs/ReviewTabs'
-
-export async function generateMetadata(): Promise<Metadata> {
-  return {
-    title: `Air Conditioning Review - ${ENV.NEXT_PUBLIC_PROJECT_NAME}`
-  }
-}
 
 const Page = () => {
   return (

--- a/app/(dashboard)/qna/select-equipment/ac/details-forms/review/phase-two/page.tsx
+++ b/app/(dashboard)/qna/select-equipment/ac/details-forms/review/phase-two/page.tsx
@@ -1,17 +1,9 @@
-import { Metadata } from 'next'
 import { useTranslations } from 'next-intl'
 import React from 'react'
 
 import Description from '@/components/description/Description'
-import { ENV } from '@/libs/env'
 
 import PhaseTwoForm from '../_components/phase-two-form/PhaseTwoForm'
-
-export async function generateMetadata(): Promise<Metadata> {
-  return {
-    title: `Air Conditioning Review Phase Two - ${ENV.NEXT_PUBLIC_PROJECT_NAME}`
-  }
-}
 
 const Page = () => {
   const t = useTranslations('qna')

--- a/app/(dashboard)/qna/select-equipment/ac/page.tsx
+++ b/app/(dashboard)/qna/select-equipment/ac/page.tsx
@@ -1,17 +1,9 @@
-import { Metadata } from 'next'
 import { getTranslations } from 'next-intl/server'
 import React from 'react'
 
 import Description from '@/components/description/Description'
-import { ENV } from '@/libs/env'
 
 import SelectAcRequestCards from './_components/select-ac-request-cards/SelectAcRequestCards'
-
-export async function generateMetadata(): Promise<Metadata> {
-  return {
-    title: `Select Air Conditioning Type - ${ENV.NEXT_PUBLIC_PROJECT_NAME}`
-  }
-}
 
 const Page = async () => {
   const t = await getTranslations('qna')

--- a/app/(dashboard)/qna/select-equipment/ac/tech-visit/page.tsx
+++ b/app/(dashboard)/qna/select-equipment/ac/tech-visit/page.tsx
@@ -1,17 +1,9 @@
-import { Metadata } from 'next'
 import { getTranslations } from 'next-intl/server'
 import React from 'react'
 
 import Description from '@/components/description/Description'
-import { ENV } from '@/libs/env'
 
 import TechVisitForm from './_components/tech-visit-form/TechVisitForm'
-
-export async function generateMetadata(): Promise<Metadata> {
-  return {
-    title: `Tech Visit - ${ENV.NEXT_PUBLIC_PROJECT_NAME}`
-  }
-}
 
 const Page = async () => {
   const t = await getTranslations('qna')

--- a/app/(dashboard)/qna/select-equipment/ac/tech-visit/review/page.tsx
+++ b/app/(dashboard)/qna/select-equipment/ac/tech-visit/review/page.tsx
@@ -1,17 +1,9 @@
-import { Metadata } from 'next'
 import { getTranslations } from 'next-intl/server'
 import React from 'react'
 
 import Description from '@/components/description/Description'
-import { ENV } from '@/libs/env'
 
 import TechVisitForm from '../_components/tech-visit-form/TechVisitForm'
-
-export async function generateMetadata(): Promise<Metadata> {
-  return {
-    title: `Tech Visit Review - ${ENV.NEXT_PUBLIC_PROJECT_NAME}`
-  }
-}
 
 const Page = async () => {
   const t = await getTranslations('qna')

--- a/app/(dashboard)/qna/select-equipment/page.tsx
+++ b/app/(dashboard)/qna/select-equipment/page.tsx
@@ -1,17 +1,9 @@
-import { Metadata } from 'next'
 import { getTranslations } from 'next-intl/server'
 import React from 'react'
 
 import Description from '@/components/description/Description'
-import { ENV } from '@/libs/env'
 
 import SelectEquipmentForm from './_components/select-equipment-form/SelectEquipmentForm'
-
-export async function generateMetadata(): Promise<Metadata> {
-  return {
-    title: `Select equipment - ${ENV.NEXT_PUBLIC_PROJECT_NAME}`
-  }
-}
 
 const Page = async () => {
   const t = await getTranslations('qna')

--- a/app/(dashboard)/qna/select-equipment/refrigeration/page.tsx
+++ b/app/(dashboard)/qna/select-equipment/refrigeration/page.tsx
@@ -1,15 +1,6 @@
-import { Metadata } from 'next'
 import React from 'react'
 
-import { ENV } from '@/libs/env'
-
 import RefrigerationTabsContent from './_components/refrigeration-tabs-content/RefrigerationTabsContent'
-
-export async function generateMetadata(): Promise<Metadata> {
-  return {
-    title: `Refrigeration - ${ENV.NEXT_PUBLIC_PROJECT_NAME}`
-  }
-}
 
 const Page = () => {
   return <RefrigerationTabsContent />

--- a/app/(dashboard)/qna/select-equipment/refrigeration/review/page.tsx
+++ b/app/(dashboard)/qna/select-equipment/refrigeration/review/page.tsx
@@ -1,15 +1,6 @@
-import { Metadata } from 'next'
 import React from 'react'
 
-import { ENV } from '@/libs/env'
-
 import RefrigerationTabsContent from '../_components/refrigeration-tabs-content/RefrigerationTabsContent'
-
-export async function generateMetadata(): Promise<Metadata> {
-  return {
-    title: `Refrigeration Preview - ${ENV.NEXT_PUBLIC_PROJECT_NAME}`
-  }
-}
 
 const Page = () => {
   return <RefrigerationTabsContent inPreview />

--- a/app/(dashboard)/qna/select-language/page.tsx
+++ b/app/(dashboard)/qna/select-language/page.tsx
@@ -1,17 +1,9 @@
-import { Metadata } from 'next'
 import { getTranslations } from 'next-intl/server'
 import React from 'react'
 
 import Description from '@/components/description/Description'
-import { ENV } from '@/libs/env'
 
 import SelectLanguageCards from './_components/select-language-cards/SelectLanguageCards'
-
-export async function generateMetadata(): Promise<Metadata> {
-  return {
-    title: `Select language - ${ENV.NEXT_PUBLIC_PROJECT_NAME}`
-  }
-}
 
 const Page = async () => {
   const t = await getTranslations('qna')

--- a/app/(dashboard)/qna/success/page.tsx
+++ b/app/(dashboard)/qna/success/page.tsx
@@ -1,15 +1,6 @@
-import { Metadata } from 'next'
 import { Suspense } from 'react'
 
-import { ENV } from '@/libs/env'
-
 import SuccessLayout from './_components/success-layout/SuccessLayout'
-
-export async function generateMetadata(): Promise<Metadata> {
-  return {
-    title: `Success - ${ENV.NEXT_PUBLIC_PROJECT_NAME}`
-  }
-}
 
 const Page = () => {
   return (


### PR DESCRIPTION
This pull request refactors the QnA pages by moving the metadata generation from individual page components to a centralized layout component. This change reduces code duplication and improves maintainability.